### PR TITLE
Corrected adduct calculations

### DIFF
--- a/ming_mass_spec_library.py
+++ b/ming_mass_spec_library.py
@@ -24,7 +24,7 @@ def get_adduct_mass(exact_mass, adduct):
         return M/3 + 8.334590, 3
 
     if adduct == ('M+H+2Na'):
-        return M/3 + 15.7661904, 3
+        return M/3 + 15.661906, 3
 
     if adduct == ('M+3Na'):
         return M/3 + 22.989218, 3
@@ -57,7 +57,7 @@ def get_adduct_mass(exact_mass, adduct):
         return M + 1.007276, 1
 
     if adduct == ('M+H-H2O'):
-        return M + 19.01839 + 1.007276 + 1.007276, 1
+        return M - 17.003288, 1
 
     if adduct == ('M+NH4'):
         return M + 18.033823, 1
@@ -114,7 +114,7 @@ def get_adduct_mass(exact_mass, adduct):
         return 2*M + 64.015765, 1
 
     if adduct == ('M-H2O+H'):
-        return M - 17.00384, 1
+        return M - 17.003288, 1
 
     if adduct == ('M-3H'):
         return M/3 - 1.007276, -3
@@ -123,19 +123,19 @@ def get_adduct_mass(exact_mass, adduct):
         return M/2 - 1.007276, -2
 
     if adduct == ('M-H2O-H'):
-        return M - 19.01839, -1
+        return M - 19.017841, -1
 
     if adduct == ('M-H'):
         return M - 1.007276, -1
 
     if adduct == ('M+Na-2H'):
-        return M + 20.974666, -2
+        return M + 20.974666, -1
 
     if adduct == ('M+Cl'):
-        return M + 34.969402, 1
+        return M + 34.969402, -1
 
     if adduct == ('M+K-2H'):
-        return M + 36.948606, -2
+        return M + 36.948606, -1
 
     if adduct == ('M+FA-H'):
         return M + 44.998201, -1
@@ -144,7 +144,7 @@ def get_adduct_mass(exact_mass, adduct):
         return M + 59.013851, -1
 
     if adduct == ('M+Br'):
-        return M + 78.918885, 1
+        return M + 78.918885, -1
 
     if adduct == ('M+TFA-H'):
         return M + 112.985586, -1


### PR DESCRIPTION
# Summary

The 'get_adduct_mass' function calculates the masses and charges for adducts which are used in downstream workflows. This pull request corrects the mass calculations or charges associated with 8 adducts. 

# Additional Information

The correction masses were re-calculated using atomic weights derived from the NIST Atomic Weights and Isotopic Compositions database. NIST mass values were rounded to 8 decimal places. A table of relevant atomic masses and charges is described below. 

| Symbol  | Mass (a.u.) | Charge (a.u) |
| ------------- | ------------- | ------------- |
| e-  | 0.00054858  | -1 |
| Na+ | 22.98922070  | 1 |
| K+ | 38.96315791  | 1 |
| Cl- | 34.96940126  | -1 |
| Br- | 78.91888618  | -1 |
| H  | 1.00782503  | 0 |
| O | 15.99491462 | 0 |

# Sources

Coursey, J.S., Schwab, D.J., Tsai, J.J., and Dragoset, R.A. (2015), Atomic Weights and Isotopic Compositions (version 4.1). [Online] Available: http://physics.nist.gov/Comp [2022, 11, 15]. National Institute of Standards and Technology, Gaithersburg, MD