### PR TITLE
Fail hard when no scan numbers. Output empty DF if no scans.

### DIFF
--- a/library_summary.py
+++ b/library_summary.py
@@ -28,7 +28,7 @@ def main():
             if line == "END IONS":
                 raise ValueError('No Scan Numbers')
 
-    with mgf.read(args.library) as reader:
+    with mgf.read(args.library, index_by_scans=True) as reader:
         for spectrum in reader:
             # We will use the spectrum ID as the key for the dictionary
             spectrum_id = spectrum['params'].get('spectrumid', spectrum['params'].get('title', "No ID"))


### PR DESCRIPTION
Pyteomics will not raise an error if there is no `SCANS=` line in the MGF file, and will instead return an empty list.

This should throw an error that is handled by the calling code.

Additionally, if there are no scans, an empty dataframe with headers should be returned to facilitate the Nextflow `collectFile` pattern